### PR TITLE
Add WebHook config and implement minigame hooks

### DIFF
--- a/IdlePlus.ExampleAddon/IdlePlus.ExampleAddon.csproj
+++ b/IdlePlus.ExampleAddon/IdlePlus.ExampleAddon.csproj
@@ -97,6 +97,7 @@
         <Reference Include="System.Core"/>
         <Reference Include="System.Data"/>
         <Reference Include="System.Xml"/>
+        <Reference Include="System.Net.Http"/>
         <Reference Include="Unity.TextMeshPro">
           <HintPath>..\libs\interop\Unity.TextMeshPro.dll</HintPath>
         </Reference>

--- a/IdlePlus/IdlePlus.csproj
+++ b/IdlePlus/IdlePlus.csproj
@@ -100,6 +100,7 @@
         <Reference Include="System.Core"/>
         <Reference Include="System.Data"/>
         <Reference Include="System.Xml"/>
+        <Reference Include="System.Net.Http"/>
         <Reference Include="Unity.TextMeshPro">
           <HintPath>..\libs\interop\Unity.TextMeshPro.dll</HintPath>
         </Reference>

--- a/IdlePlus/src/API/Unity/MouseEventManager.cs
+++ b/IdlePlus/src/API/Unity/MouseEventManager.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using IdlePlus.Utilities;
 using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using Type = Il2CppSystem.Type;
@@ -52,16 +54,9 @@ namespace IdlePlus.API.Unity {
 				break;
 			}
 
-			var leftPressed = Input.GetMouseButtonDown(0);
-			var rightPressed = Input.GetMouseButtonDown(1);
-						
-			MouseEventData eventData = new MouseEventData(Input.mousePosition, leftPressed, rightPressed);
+			MouseEventData eventData = new MouseEventData(Input.mousePosition);
 			ProcessEnterExit(eventData, result?.gameObject);
 			ProcessMove(eventData);
-			
-			if (leftPressed || rightPressed) {
-				ExecuteEvent(Selected.GameObject, eventData, MouseEventFunctions.MouseClickFunc);
-			}
 		}
 
 		private static void ProcessEnterExit(MouseEventData data, GameObject current) {
@@ -175,7 +170,6 @@ namespace IdlePlus.API.Unity {
 
 			public RegisteredType(System.Type type, RegisteredTypeFactory factory) {
 				this._factory = factory;
-				if (typeof(IMouseClickHandler).IsAssignableFrom(type)) this._supports.Add(typeof(IMouseClickHandler));
 				if (typeof(IMouseEnterHandler).IsAssignableFrom(type)) this._supports.Add(typeof(IMouseEnterHandler));
 				if (typeof(IMouseExitHandler).IsAssignableFrom(type)) this._supports.Add(typeof(IMouseExitHandler));
 				if (typeof(IMouseMoveHandler).IsAssignableFrom(type)) this._supports.Add(typeof(IMouseMoveHandler));
@@ -191,20 +185,9 @@ namespace IdlePlus.API.Unity {
 	public class MouseEventData {
 		
 		public readonly Vector3 MousePosition;
-
-		/// <summary>
-		/// If the left mouse button was just pressed.
-		/// </summary>
-		public readonly bool LeftClickPressed;
-		/// <summary>
-		/// If the right mouse button was just pressed.
-		/// </summary>
-		public readonly bool RightClickPressed;
 		
-		public MouseEventData(Vector3 mousePosition, bool leftClickPressed, bool rightClickPressed) {
+		public MouseEventData(Vector3 mousePosition) {
 			this.MousePosition = mousePosition;
-			this.LeftClickPressed = leftClickPressed;
-			this.RightClickPressed = rightClickPressed;
 		}
 	}
 
@@ -218,16 +201,9 @@ namespace IdlePlus.API.Unity {
 
 		internal static readonly MouseEventFunc<IMouseExitHandler> MouseExitFunc =
 			(handler, data) => handler.HandleMouseExit(data);
-		
-		internal static readonly MouseEventFunc<IMouseClickHandler> MouseClickFunc =
-			(handler, data) => handler.HandleMouseClick(data);
 	}
 
 	public interface IMouseEvent {}
-	
-	public interface IMouseClickHandler : IMouseEvent {
-		void HandleMouseClick(MouseEventData data);
-	}
 	
 	public interface IMouseEnterHandler : IMouseEvent {
 		void HandleMouseEnter(MouseEventData data);

--- a/IdlePlus/src/Command/Commands/DevelopmentCommand.cs
+++ b/IdlePlus/src/Command/Commands/DevelopmentCommand.cs
@@ -3,10 +3,12 @@ using System.IO;
 using Brigadier.NET;
 using Brigadier.NET.Context;
 using Databases;
+using IdlePlus.Utilities;
 using IdlePlus.Utilities.Extensions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Player;
+using System.Threading.Tasks;
 
 namespace IdlePlus.Command.Commands {
 	internal static class DevelopmentCommand {
@@ -25,6 +27,32 @@ namespace IdlePlus.Command.Commands {
 			command.Then(Literal.Of("say")
 				.Then(Argument.Of("message", Arguments.GreedyString())
 					.Executes(HandleSay)));
+
+			// Webhook Commands with more descriptive names
+			var webhookCommand = Literal.Of("webhook");
+
+			// Run all predefined tests
+			webhookCommand.Then(Literal.Of("run-test")
+				.Executes(HandleWebhookRunTests));
+
+			// Start repeating test runner
+			webhookCommand.Then(Literal.Of("run-test-repeater")
+				.Executes(context => HandleWebhookStartTestRepeater(context, 5))
+				.Then(Argument.Of("seconds-interval", Arguments.Integer(1, 60))
+					.Executes(context => HandleWebhookStartTestRepeater(context, context.GetArgument<int>("seconds-interval")))));
+
+			// Stop repeating test runner
+			webhookCommand.Then(Literal.Of("stop-test-repeater").Executes(HandleWebhookStopTestRepeater));
+
+			// Display status information
+			webhookCommand.Then(Literal.Of("status-test-repeater").Executes(HandleWebhookStatus));
+
+			// Metrics and statistics commands
+			webhookCommand.Then(Literal.Of("show-metrics").Executes(HandleWebhookShowMetrics));
+			webhookCommand.Then(Literal.Of("reset-metrics").Executes(HandleWebhookResetMetrics));
+
+			// Add the webhook command to the main command
+			command.Then(webhookCommand);
 
 			registry.Register(command);
 		}
@@ -91,6 +119,119 @@ namespace IdlePlus.Command.Commands {
 			var message = context.GetArgument<string>("message");
 			message = $"[00:00:00] [TAG] {PlayerData.Instance.Username}: {message}";
 			sender.SendMessage(message, mode: GameMode.Default, premium: true, moderator: true);
+		}
+
+		/*
+         * Webhook Command Handlers
+         */
+
+		/// <summary>
+		/// Runs all predefined webhook tests
+		/// </summary>
+		private static int HandleWebhookRunTests(CommandContext<CommandSender> context) {
+			try {
+				IdleLog.Info("[DevCommand] Running all predefined webhook tests...");
+				WebhookTests.RunTests();
+				IdleLog.Info("[DevCommand] All webhook tests have been queued.");
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error running webhook tests: {ex.Message}");
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Starts a repeating test sequence that runs at regular intervals
+		/// </summary>
+		private static int HandleWebhookStartTestRepeater(CommandContext<CommandSender> context, int intervalSeconds) {
+			try {
+				bool started = WebhookTests.StartTestRepeater(intervalSeconds);
+
+				if (started) {
+					IdleLog.Info($"[DevCommand] Started webhook test repeater. Running tests every {intervalSeconds} seconds.");
+				} else {
+					IdleLog.Info("[DevCommand] Test repeater is already running. Stop it first if you want to restart with different settings.");
+				}
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error starting webhook test repeater: {ex.Message}");
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Stops the repeating test sequence
+		/// </summary>
+		private static int HandleWebhookStopTestRepeater(CommandContext<CommandSender> context) {
+			try {
+				bool stopped = WebhookTests.StopTestRepeater();
+
+				if (stopped) {
+					IdleLog.Info("[DevCommand] Webhook test repeater has been stopped.");
+				} else {
+					IdleLog.Info("[DevCommand] No test repeater is currently running.");
+				}
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error stopping webhook test repeater: {ex.Message}");
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Shows the current status of the webhook system
+		/// </summary>
+		private static int HandleWebhookStatus(CommandContext<CommandSender> context) {
+			try {
+				bool isRunning = WebhookTests.IsRepeaterRunning();
+				int queuedCount = WebhookManager.GetQueuedRequestCount();
+
+				var statusMessage = new System.Text.StringBuilder();
+				statusMessage.AppendLine("Webhook System Status:");
+
+				if (isRunning) {
+					int interval = WebhookTests.GetRepeaterInterval();
+					statusMessage.AppendLine($"- Automatic testing: Running (every {interval} seconds)");
+				} else {
+					statusMessage.AppendLine("- Automatic testing: Not running");
+				}
+
+				statusMessage.AppendLine($"- Pending requests: {queuedCount}");
+
+				IdleLog.Info($"[DevCommand] Webhook status:\n{statusMessage}");
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error checking webhook status: {ex.Message}");
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Shows metrics and statistics about webhook performance
+		/// </summary>
+		private static int HandleWebhookShowMetrics(CommandContext<CommandSender> context) {
+			try {
+				string report = WebhookMetrics.GetReport();
+				IdleLog.Info($"[DevCommand] Webhook metrics:\n{report}");
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error getting webhook metrics: {ex.Message}");
+				return 0;
+			}
+		}
+
+		/// <summary>
+		/// Resets all webhook performance metrics
+		/// </summary>
+		private static int HandleWebhookResetMetrics(CommandContext<CommandSender> context) {
+			try {
+				WebhookMetrics.Reset();
+				IdleLog.Info("[DevCommand] All webhook performance metrics have been reset to zero.");
+				return 1;
+			} catch (Exception ex) {
+				IdleLog.Error($"[DevCommand] Error resetting webhook metrics: {ex.Message}");
+				return 0;
+			}
 		}
 	}
 }

--- a/IdlePlus/src/Patches/Minigame/MinigameEndPatch.cs
+++ b/IdlePlus/src/Patches/Minigame/MinigameEndPatch.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using Minigames;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Minigame {
+	[HarmonyPatch(typeof(MinigameManager), "EndMinigame")]
+	public class EndGameEventPatch {
+		[HarmonyPostfix]
+		public static void Postfix() {
+			WebhookManager.AddSendWebhook(
+				WebhookType.Minigame,
+				new Dictionary<string, string>
+				{
+					{ "action", "stop" },
+					{ "type", MinigameTracker.LastEventType.ToString() }
+				}
+			);
+
+			MinigameTracker.LastEventType = global::Guilds.UI.ClanEventType.None;
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Minigame/MinigameStartPatch.cs
+++ b/IdlePlus/src/Patches/Minigame/MinigameStartPatch.cs
@@ -1,0 +1,23 @@
+using HarmonyLib;
+using Minigames;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Minigame {
+	[HarmonyPatch(typeof(MinigameManager), "StartGame")]
+	public class StartGameEventPatch {
+		[HarmonyPostfix]
+		public static void Postfix(Minigames.Minigame minigame) {
+			MinigameTracker.LastEventType = minigame.EventType;
+
+			WebhookManager.AddSendWebhook(
+				WebhookType.Minigame,
+				new Dictionary<string, string>
+				{
+					{ "action", "start" },
+					{ "type", minigame.EventType.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Minigame/MinigameTracker.cs
+++ b/IdlePlus/src/Patches/Minigame/MinigameTracker.cs
@@ -1,0 +1,5 @@
+namespace IdlePlus.Patches.Minigame {
+	public static class MinigameTracker {
+		public static global::Guilds.UI.ClanEventType LastEventType { get; set; } = global::Guilds.UI.ClanEventType.None;
+	}
+}

--- a/IdlePlus/src/Settings/ModSettings.cs
+++ b/IdlePlus/src/Settings/ModSettings.cs
@@ -1,9 +1,12 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using IdlePlus.Settings.Types;
 using Path = System.IO.Path;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
 
 namespace IdlePlus.Settings {
 	
@@ -146,6 +149,54 @@ namespace IdlePlus.Settings {
 			public static StringDropdownSetting CurrentPack;
 		}
 		#endregion
+
+
+		#region Hooks
+		public static readonly SettingCategory HooksCategory = SettingCategory.Create(
+			"WebHooks",
+			new Setting[] { Hooks.BackendHookServer, Hooks.BackendHookBarrer }
+				.Concat(Hooks.WebhookToggles.Values.Cast<Setting>())
+				.ToArray()
+		);
+
+		public static class Hooks {
+			public static readonly StringSetting BackendHookServer = StringSetting.Create(
+				"hook_backendUrl",
+				"The URL for the backend hook server.",
+				"",
+				@"^(http:\/\/|https:\/\/).{4,}$",
+				"Invalid URL. It must start with http:// or https:// and be a valid domain."
+			);
+
+			public static readonly StringSetting BackendHookBarrer = StringSetting.Create(
+				"hook_backendBarrer",
+				"Security Barrer for Backend API",
+				"",
+				@"^[A-Za-z0-9]{8,}$",
+				"Invalid token format. Please enter at least 8 alphanumeric characters."
+			);
+
+			public static readonly Dictionary<WebhookType, ToggleSetting> WebhookToggles = CreateWebhookToggles();
+
+			/// <summary>
+			/// Creates a dictionary that maps each WebhookType to its corresponding ToggleSetting.
+			/// The ToggleSetting is generated based on the configuration obtained from the WebhookConfigProvider.
+			/// The setting ID is formed by appending "WebHook" to the webhook type's name, and the display name is built by combining
+			/// the configured settings name, the request method, and the URL path.
+			/// </summary>
+			/// <returns>A dictionary mapping each WebhookType to a ToggleSetting.</returns>
+			private static Dictionary<WebhookType, ToggleSetting> CreateWebhookToggles() {
+				var toggles = new Dictionary<WebhookType, ToggleSetting>();
+				foreach (WebhookType webhook in Enum.GetValues(typeof(WebhookType))) {
+					var config = WebhookConfigProvider.GetConfig(webhook);
+					string id = webhook.ToString() + "WebHook";
+					string displayName = $"{config.SettingsName}\n{config.RequestMethod} {config.UrlPath}";
+					toggles[webhook] = ToggleSetting.Create(id, displayName, false);
+				}
+				return toggles;
+			}
+		}
+		#endregion
         
 		#region Miscellaneous
 		
@@ -174,7 +225,7 @@ namespace IdlePlus.Settings {
 		// Category registration, each category must be registered here, if not
 		// it won't be loaded or saved.
 		public static readonly SettingCategory[] Categories = { FeaturesCategory, UICategory, MarketValueCategory,
-			TexturePackCategory, MiscellaneousCategory };
+			TexturePackCategory, HooksCategory, MiscellaneousCategory };
 		
 		#region Save/Load
 		
@@ -228,7 +279,6 @@ namespace IdlePlus.Settings {
 			});
 		}
 		
-		#endregion
-		
+		#endregion		
 	}
 }

--- a/IdlePlus/src/Settings/Types/StringSetting.cs
+++ b/IdlePlus/src/Settings/Types/StringSetting.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Text;
+using IdlePlus.Settings.Unity;
+using IdlePlus.Utilities;
+using IdlePlus.Utilities.Extensions;
+using IdlePlus.Utilities.Helpers;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI.ProceduralImage;
+using Object = UnityEngine.Object;
+
+namespace IdlePlus.Settings.Types {
+	public class StringSetting : Setting {
+		private static GameObject _prefab;
+		public const string InputFieldName = "InputField";
+		public const string ErrorTextName = "ErrorText";
+
+		public string Value { get; private set; }
+
+		public string RegexPattern { get; private set; }
+
+		public string ErrorMessage { get; private set; }
+
+		public StringSetting(string id, string description, string defaultValue, string regexPattern = null, string errorMessage = null) {
+			Id = id;
+			Description = description;
+			Value = defaultValue;
+			RegexPattern = regexPattern;
+			ErrorMessage = errorMessage;
+		}
+
+		public void Set(string newValue) {
+			Value = newValue;
+		}
+
+		#region Serialization
+
+		public override byte[] Serialize() {
+			return Encoding.UTF8.GetBytes(Value);
+		}
+
+		public override void Deserialize(byte[] data) {
+			try {
+				Value = Encoding.UTF8.GetString(data);
+				IdleLog.Info($"Deserialized string setting: {Id}, value: {Value}");
+			} catch (Exception e) {
+				IdleLog.Error($"Failed to deserialize string setting: {Id}", e);
+			}
+		}
+
+		#endregion
+
+		#region Prefab
+
+		public override void Initialize(GameObject obj) {
+			var entry = obj.With<StringSettingEntry>();
+			entry.Initialize();
+		}
+
+		public override GameObject GetPrefab() {
+			if (_prefab == null)
+				CreatePrefab();
+
+			var obj = Object.Instantiate(_prefab);
+			obj.With<StringSettingEntry>().Setting = this;
+			obj.name = Id;
+			return obj;
+		}
+
+		private static void CreatePrefab() {
+			// Create a container rect object.
+			var obj = GameObjects.NewRect("StringSettingPrefab", UiHelper.PrefabContainer);
+			obj.With<RectTransform>().sizeDelta = Vec2.Vec(350, 100);
+			obj.With<ProceduralImage>().color = new Color(0, 0, 0, 0.13f);
+			obj.With<UniformModifier>().radius = 10;
+
+			// Create an InputField for text input.
+			var inputObj = UiHelper.CreateInputField(InputFieldName, obj.transform);
+			inputObj.name = InputFieldName;
+			inputObj.transform.localPosition = Vec3.Vec(160, 0, 0);
+			var inputRect = inputObj.GetComponent<RectTransform>();
+			inputRect.sizeDelta = new Vector2(200, 0);
+
+			// Create an error text element for validation messages.
+			var errorObj = GameObjects.NewRect<TextMeshProUGUI>(ErrorTextName, obj);
+			errorObj.name = ErrorTextName;
+			errorObj.transform.localPosition = Vec3.Vec(0, -30, 0);
+			var errorRect = errorObj.Use<RectTransform>();
+			errorRect.sizeDelta = Vec2.Vec(200, 20);
+			var errorText = errorObj.Use<TextMeshProUGUI>();
+			errorText.text = ""; // start empty
+			errorText.fontSize = 14;
+			errorText.color = Color.red;
+
+			_prefab = obj;
+		}
+
+		#endregion
+
+		public static StringSetting Create(string id, string description, string defaultValue, string regexPattern = null, string errorMessage = null) {
+			return new StringSetting(id, description, defaultValue, regexPattern, errorMessage);
+		}
+	}
+}

--- a/IdlePlus/src/Settings/Unity/StringSettingEntry.cs
+++ b/IdlePlus/src/Settings/Unity/StringSettingEntry.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using IdlePlus.Attributes;
+using IdlePlus.Settings.Types;
+using IdlePlus.Utilities.Extensions;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using IdlePlus.Utilities;
+
+namespace IdlePlus.Settings.Unity {
+	[RegisterIl2Cpp]
+	public class StringSettingEntry : MonoBehaviour {
+		public StringSetting Setting;
+		private bool _initialized;
+		private TMP_InputField _inputField;
+		private TextMeshProUGUI _errorText;
+
+		public void Initialize() {
+			if (_initialized) return;
+			_initialized = true;
+
+			_inputField = gameObject.Find("InputField")?.GetComponent<TMP_InputField>();
+			if (_inputField == null) {
+				IdleLog.Info("StringSettingEntry: InputField not found.");
+				return;
+			}
+
+			_errorText = gameObject.Find("ErrorText")?.GetComponent<TextMeshProUGUI>();
+
+			// Remove restrictions and set character limit.
+			_inputField.characterValidation = TMP_InputField.CharacterValidation.None;
+			_inputField.characterLimit = 200;
+			_inputField.text = Setting.Value;
+
+			_inputField.onEndEdit.AddListener((UnityEngine.Events.UnityAction<string>)((string s) => OnInputFieldChanged(s)));
+
+			// Set placeholder text after a short delay.
+			Invoke(nameof(SetPlaceholder), 0.5f);
+		}
+
+		public void Setup() {
+			if (_inputField != null)
+				_inputField.text = Setting.Value;
+		}
+
+		private void SetPlaceholder() {
+			if (_inputField != null && _inputField.placeholder != null) {
+				var tmp = _inputField.placeholder.GetComponent<TextMeshProUGUI>();
+				if (tmp != null) {
+					tmp.text = Setting.Description;
+				}
+			}
+		}
+
+		private void OnInputFieldChanged(string newValue) {
+			if (_inputField != null) {
+				// If input is empty, accept it without validation.
+				if (string.IsNullOrEmpty(newValue)) {
+					Setting.Set(newValue);
+					if (_errorText != null)
+						_errorText.text = "";
+					ModSettings.Save();
+					return;
+				}
+
+				// If a regex pattern is provided, validate the input.
+				if (!string.IsNullOrEmpty(Setting.RegexPattern)) {
+					if (!Regex.IsMatch(newValue, Setting.RegexPattern, RegexOptions.IgnoreCase)) {
+						// If validation fails, display the provided error message (or a default one) and revert.
+						if (_errorText != null) {
+							_errorText.text = !string.IsNullOrEmpty(Setting.ErrorMessage)
+								? Setting.ErrorMessage
+								: "Invalid input format.";
+						}
+						_inputField.text = Setting.Value;
+						return;
+					} else {
+						if (_errorText != null)
+							_errorText.text = "";
+					}
+				}
+
+				Setting.Set(newValue);
+				ModSettings.Save();
+			}
+		}
+
+		public void SetSetting(StringSetting setting) {
+			Setting = setting;
+			Setup();
+		}
+	}
+}

--- a/IdlePlus/src/Unity/Chat/ChatItemLinkDisplay.cs
+++ b/IdlePlus/src/Unity/Chat/ChatItemLinkDisplay.cs
@@ -3,8 +3,6 @@ using IdlePlus.API.Unity;
 using IdlePlus.API.Utility;
 using IdlePlus.Attributes;
 using IdlePlus.Utilities;
-using Navigation;
-using PlayerMarket;
 using Popups;
 using TMPro;
 using UnityEngine;
@@ -14,16 +12,13 @@ using UnityEngine.SceneManagement;
 namespace IdlePlus.Unity.Chat {
 	
 	[RegisterIl2Cpp]
-	public class ChatItemLinkDisplay : MonoBehaviour, IMouseEnterHandler, IMouseExitHandler, IMouseMoveHandler, IMouseClickHandler {
+	public class ChatItemLinkDisplay : MonoBehaviour, IMouseEnterHandler, IMouseExitHandler, IMouseMoveHandler {
 		
 		private static Camera _camera;
-		private static PlayerMarketPage _market;
 		
 		private InventoryItemHoverPopup _popup;
 		private TextMeshProUGUI _text;
-		
 		private string _selected;
-		private Item _selectedItem;
 
 		[InitializeOnce(OnSceneLoad = Scenes.Anything)]
 		private static void InitializeOnce() {
@@ -41,27 +36,6 @@ namespace IdlePlus.Unity.Chat {
 		
 		public void Awake() {
 			if (!_camera) _camera = GameObject.Find("Main Camera").GetComponent<Camera>();
-		}
-		
-		public void HandleMouseClick(MouseEventData data) {
-			if (this._selected == null || this._selectedItem == null) return;
-			if (!data.LeftClickPressed) return;
-
-			if (_market == null) {
-				_market = FindObjectOfType<PlayerMarketPage>(true);
-				if (_market == null) {
-					IdleLog.Warn("Couldn't find PlayerMarketPage.");
-					return;
-				}
-			}
-
-			PopupManager.Instance.CloseAllActivePopups();
-			NavigationManager.Instance.SelectTab(Content.PlayerMarket);
-
-			_market.OnSearchButtonPressed();
-			_market._frontPageContainer.SetActive(false);
-			_market._offerPage.gameObject.SetActive(false);
-			_market._searchPage.SelectItemAsync(this._selectedItem);
 		}
 
 		public void HandleMouseEnter(MouseEventData data) {
@@ -129,7 +103,6 @@ namespace IdlePlus.Unity.Chat {
 			
 			var itemId = int.Parse(linkId.Substring(5));
 			var item = ItemDatabase.ItemList[itemId];
-			this._selectedItem = item;
 			
 			PopupManager.Instance.SetupHardPopup(HardPopup.InventoryItemHoverPopup, false, false);
 			var worldPos = _camera.ScreenToWorldPoint(data.MousePosition);

--- a/IdlePlus/src/Utilities/Helpers/JsonHelper.cs
+++ b/IdlePlus/src/Utilities/Helpers/JsonHelper.cs
@@ -1,0 +1,72 @@
+using System;
+using Newtonsoft.Json;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Helper class for JSON operations.
+	/// </summary>
+	public static class JsonHelper {
+		/// <summary>
+		/// Takes a JSON string, validates it, and returns it if valid.
+		/// </summary>
+		/// <param name="json">The JSON string to validate.</param>
+		/// <returns>The same JSON string if it is valid.</returns>
+		/// <exception cref="ArgumentException">Thrown when the provided string is not valid JSON.</exception>
+		public static string Serialize(string json) {
+			if (string.IsNullOrEmpty(json))
+				return json;
+
+			if (!IsValidJson(json))
+				throw new ArgumentException($"The provided string is not valid JSON. Value: {json}", nameof(json));
+
+			return json;
+		}
+
+		/// <summary>
+		/// Serializes an Il2CppSystem.Object using JsonConvert.
+		/// </summary>
+		/// <param name="il2cppObj">The Il2CppSystem.Object to serialize.</param>
+		/// <returns>The resulting JSON string.</returns>
+		/// <exception cref="InvalidOperationException">Thrown when serialization fails or produces invalid JSON.</exception>
+		public static string Serialize(Il2CppSystem.Object il2cppObj) {
+			if (il2cppObj == null)
+				return null;
+
+			try {
+				string result = JsonConvert.SerializeObject(il2cppObj);
+				if (IsValidJson(result)) {
+					return result;
+				} else {
+					throw new InvalidOperationException($"Serialization produced invalid JSON: {result}");
+				}
+			} catch (Exception ex) {
+				throw new InvalidOperationException("Error serializing the Il2Cpp object.", ex);
+			}
+		}
+
+		/// <summary>
+		/// Validates whether the given string is valid JSON.
+		/// </summary>
+		/// <param name="json">The JSON string to validate.</param>
+		/// <returns>True if the string is valid JSON; otherwise, false.</returns>
+		public static bool IsValidJson(string json) {
+			if (string.IsNullOrEmpty(json))
+				return false;
+
+			json = json.Trim();
+
+			if ((json.StartsWith("{") && json.EndsWith("}")) ||
+				(json.StartsWith("[") && json.EndsWith("]"))) {
+				try {
+					// Use JsonConvert for validation
+					JsonConvert.DeserializeObject(json);
+					return true;
+				} catch (Exception) {
+					return false;
+				}
+			}
+
+			return false;
+		}
+	}
+}

--- a/IdlePlus/src/Utilities/Helpers/UiHelper.cs
+++ b/IdlePlus/src/Utilities/Helpers/UiHelper.cs
@@ -15,6 +15,7 @@ namespace IdlePlus.Utilities.Helpers {
 		public static GameObject PrefabContainer;
 		private static GameObject _baseDropdown;
 		private static GameObject _baseToggle;
+		private static GameObject _baseInputField;
 		
 		[InitializeOnce(Priority = InitPriority.UiHelper, OnSceneLoad = "*")]
 		private static void InitializeOnce() {
@@ -25,6 +26,7 @@ namespace IdlePlus.Utilities.Helpers {
 			
 			InitializeDropdown();
 			InitializeToggle();
+			InitializeInputField();
 		}
 
 		private static void InitializeDropdown() {
@@ -64,7 +66,19 @@ namespace IdlePlus.Utilities.Helpers {
 			leanToggle.onOff = new UnityEvent();
 			leanToggle.onOn = new UnityEvent();
 		}
-		
+
+		private static void InitializeInputField() {
+			var copyInputField = GameObjects.FindByPathNonNull("PopupManager/Canvas/HardPopups/SettingsPopup2/Panels/BlocksSection/BlockPlayerInputField");
+			if (copyInputField != null) {
+				_baseInputField = Object.Instantiate(copyInputField, PrefabContainer.transform, false);
+				_baseInputField.name = "IdlePlusInputField";
+			} else {
+				IdleLog.Info("InputField prefab not found by path!");
+			}
+		}
+
+
+
 		public static GameObject CreateDropdown(string name, Transform parent = null) {
 			var dropdown = Object.Instantiate(_baseDropdown);
 			dropdown.name = name;
@@ -81,6 +95,23 @@ namespace IdlePlus.Utilities.Helpers {
 			toggle.name = name;
 			if (parent != null) toggle.transform.SetParent(parent, false);
 			return toggle;
+		}
+
+		public static GameObject CreateInputField(string name, Transform parent = null) {
+			if (_baseInputField == null) {
+				InitializeInputField();
+			}
+			if (_baseInputField == null) {
+				var fallback = new GameObject(name);
+				fallback.AddComponent<RectTransform>();
+				return fallback;
+			}
+			var inputField = Object.Instantiate(_baseInputField);
+			inputField.name = name;
+			if (parent != null) {
+				inputField.transform.SetParent(parent, false);
+			}
+			return inputField;
 		}
 	}
 }

--- a/IdlePlus/src/Utilities/WebHooks/HTTPService.cs
+++ b/IdlePlus/src/Utilities/WebHooks/HTTPService.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using IdlePlus.Settings;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Handles HTTP requests for webhooks with support for timeouts, retries, and error handling.
+	/// </summary>
+	public class HttpService {
+		private static readonly HttpClient _client;
+		private static readonly HttpService _instance = new HttpService();
+		private static readonly object _lockObject = new object();
+		private static bool _isInitialized = false;
+
+		/// <summary>
+		/// Gets the singleton instance of the HttpService.
+		/// </summary>
+		public static HttpService Instance => _instance;
+
+		// Static constructor to initialize the HttpClient
+		static HttpService() {
+			try {
+				_client = new HttpClient {
+					Timeout = TimeSpan.FromSeconds(10)
+				};
+
+				// Add default headers if needed
+				// _client.DefaultRequestHeaders.Add("User-Agent", "IdlePlus Webhook Client");
+			} catch (Exception ex) {
+				IdleLog.Error($"[HttpService] Error initializing HttpClient: {ex.Message}");
+				throw; // Rethrow to prevent silent failures in static initialization
+			}
+		}
+
+		private HttpService() {
+			// Private constructor to enforce singleton pattern
+		}
+
+		/// <summary>
+		/// Initializes the HTTP service with settings from ModSettings.
+		/// </summary>
+		public void Initialize() {
+			if (_isInitialized)
+				return;
+
+			lock (_lockObject) {
+				if (_isInitialized)
+					return;
+
+				try {
+					// Any initialization code that depends on game settings
+					// For example, setting up default headers based on game settings
+
+					_isInitialized = true;
+					IdleLog.Debug("[HttpService] Initialized successfully");
+				} catch (Exception ex) {
+					IdleLog.Error($"[HttpService] Initialization error: {ex.Message}");
+				}
+			}
+		}
+
+		/// <summary>
+		/// Sends an HTTP request to the specified URL with the given method and content.
+		/// </summary>
+		/// <param name="url">The URL to send the request to.</param>
+		/// <param name="method">The HTTP method to use (GET, POST, etc.).</param>
+		/// <param name="jsonContent">The JSON content to include in the request body (for POST requests).</param>
+		/// <param name="timeoutSeconds">Timeout in seconds for this specific request.</param>
+		/// <returns>True if the request was successful; otherwise, false.</returns>
+		public async Task<bool> SendRequestAsync(string url, string method, string jsonContent, int timeoutSeconds = 10) {
+			if (!_isInitialized) {
+				Initialize();
+			}
+
+			if (string.IsNullOrEmpty(url)) {
+				IdleLog.Error("[HttpService] URL cannot be null or empty");
+				return false;
+			}
+
+			try {
+				using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds))) {
+					HttpMethod httpMethod = GetHttpMethod(method);
+					var request = new HttpRequestMessage(httpMethod, url);
+
+					AddAuthorizationHeader(request);
+
+					if (jsonContent != null && (httpMethod == HttpMethod.Post || httpMethod == HttpMethod.Put)) {
+						request.Content = new StringContent(jsonContent, System.Text.Encoding.UTF8, "application/json");
+					}
+
+					IdleLog.Debug($"[HttpService] Sending {httpMethod} request to {url}");
+					var response = await _client.SendAsync(request, cts.Token);
+
+					// Log response details
+					IdleLog.Info($"[HttpService] Response Status: {response.StatusCode} for {url}");
+
+					if (!response.IsSuccessStatusCode) {
+						string responseContent = await response.Content.ReadAsStringAsync();
+						IdleLog.Error($"[HttpService] Request failed with status {response.StatusCode}. Response: {responseContent.Substring(0, Math.Min(responseContent.Length, 500))}");
+					}
+
+					return response.IsSuccessStatusCode;
+				}
+			} catch (TaskCanceledException) {
+				IdleLog.Error($"[HttpService] Request to {url} timed out");
+				return false;
+			} catch (HttpRequestException ex) {
+				if (ex.InnerException is WebException webEx &&
+					webEx.Status == WebExceptionStatus.NameResolutionFailure) {
+					IdleLog.Error($"[HttpService] DNS resolution failed for {url}. Check network connection and URL");
+				} else {
+					IdleLog.Error($"[HttpService] HTTP request error: {ex.Message}");
+				}
+				return false;
+			} catch (Exception ex) {
+				IdleLog.Error($"[HttpService] Error sending {method} request to {url}: {ex.Message}");
+				return false;
+			}
+		}
+
+		/// <summary>
+		/// Returns the HttpMethod corresponding to the given request method string.
+		/// </summary>
+		/// <param name="requestMethod">The HTTP method as a string.</param>
+		/// <returns>The corresponding HttpMethod object.</returns>
+		private HttpMethod GetHttpMethod(string requestMethod) {
+			if (string.IsNullOrEmpty(requestMethod)) {
+				IdleLog.Info("[HttpService] Request method is null or empty, defaulting to GET");
+				return HttpMethod.Get;
+			}
+
+			switch (requestMethod.ToUpperInvariant()) {
+				case "GET":
+					return HttpMethod.Get;
+				case "POST":
+					return HttpMethod.Post;
+				case "PUT":
+					return HttpMethod.Put;
+				case "DELETE":
+					return HttpMethod.Delete;
+				case "HEAD":
+					return HttpMethod.Head;
+				default:
+					// For less common methods
+					return new HttpMethod(requestMethod);
+			}
+		}
+
+		/// <summary>
+		/// Adds the Authorization header to the HTTP request if a token is provided.
+		/// </summary>
+		/// <param name="request">The HTTP request to add the header to.</param>
+		private void AddAuthorizationHeader(HttpRequestMessage request) {
+			try {
+				string token = ModSettings.Hooks.BackendHookBarrer.Value;
+				if (!string.IsNullOrEmpty(token)) {
+					request.Headers.TryAddWithoutValidation("Authorization", token);
+				}
+			} catch (Exception ex) {
+				IdleLog.Error($"[HttpService] Error adding authorization header: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Builds the full URL from the base URL and the path with parameters.
+		/// </summary>
+		/// <param name="baseUrl">The base URL.</param>
+		/// <param name="urlPath">The path with parameters.</param>
+		/// <returns>The complete URL.</returns>
+		public string BuildFullUrl(string baseUrl, string urlPath) {
+			if (string.IsNullOrEmpty(baseUrl)) {
+				IdleLog.Error("[HttpService] Base URL cannot be null or empty");
+				return urlPath; // Return at least the path if we have it
+			}
+
+			if (string.IsNullOrEmpty(urlPath)) {
+				return baseUrl; // Return just the base URL if path is empty
+			}
+
+			// Ensure base URL doesn't end with a slash and urlPath doesn't start with one
+			return $"{baseUrl.TrimEnd('/')}/{urlPath.TrimStart('/')}";
+		}
+	}
+}

--- a/IdlePlus/src/Utilities/WebHooks/WebhookConfigProvider.cs
+++ b/IdlePlus/src/Utilities/WebHooks/WebhookConfigProvider.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Enum defining the available webhook types.
+	/// </summary>
+	/// <remarks>
+	/// Add new webhook types here. Each type should have its corresponding configuration
+	/// in the WebhookConfigProvider._configs dictionary.
+	/// </remarks>
+	public enum WebhookType {
+		/// <summary>Minigame/clan event webhooks.</summary>
+		Minigame
+
+		// When adding a new webhook type:
+		// 1. Add it here as a new enum value
+		// 2. Add its configuration to the _configs dictionary in WebhookConfigProvider
+		// Toggle settings will be automatically created based on this enum
+	}
+
+	/// <summary>
+	/// Provides configuration settings for each webhook type.
+	/// </summary>
+	public static class WebhookConfigProvider {
+		// Dictionary holding configuration for each webhook type.
+		// 
+		// URL TEMPLATE PLACEHOLDERS:
+		// You can use the following placeholders in your URL paths:
+		// - Custom parameters from your code: {action}, {type}, etc.
+		// - Built-in metadata parameters:
+		//   {playerName} - Current player's username
+		//   {gameMode} - Player's current game mode (Default, Ironman, etc.)
+		//   {clanName} - Player's clan name, or "None" if not in a clan
+		//   {timestamp} - Current Unix timestamp (seconds since 1970-01-01)
+		//   {clientVersion} - Current mod version
+		//
+		// NOTES:
+		// - For POST/PUT requests, all metadata will also be included in the request body
+		//   under the "metadata" property.
+		// - Path parameters passed to AddSendWebhook will be included in the "params" property.
+		// - You can use any parameter name in your URL template, as long as you provide the
+		//   corresponding value in the pathParams dictionary when calling AddSendWebhook.
+		private static readonly Dictionary<WebhookType, WebhookConfig> _configs = new Dictionary<WebhookType, WebhookConfig>
+		{
+            // Minigame webhook configuration
+            // Example usage: WebhookManager.AddSendWebhook(WebhookType.Minigame, 
+            //                  new Dictionary<string, string> { { "action", "start" }, { "type", "fishing" } });
+            {
+				WebhookType.Minigame, new WebhookConfig {
+					RequestMethod = "POST",
+					UrlPath = "/minigame/{action}/{type}",
+					SettingsName = "Minigames (Clan Events)"
+				}
+			}
+            
+            // TEMPLATE FOR ADDING NEW WEBHOOK TYPES:
+            //
+            // {
+            //     WebhookType.YourNewType, new WebhookConfig {
+            //         RequestMethod = "POST", // or "GET", "PUT", etc.
+            //         UrlPath = "/your-endpoint/{param1}/{param2}",
+            //         SettingsName = "Human-Readable Name for Settings UI"
+            //     }
+            // }
+        };
+
+		/// <summary>
+		/// Retrieves the configuration for the specified webhook type.
+		/// </summary>
+		/// <param name="type">The webhook type.</param>
+		/// <returns>The corresponding <see cref="WebhookConfig"/> if found; otherwise, null.</returns>
+		public static WebhookConfig GetConfig(WebhookType type) {
+			return _configs.TryGetValue(type, out var config) ? config : null;
+		}
+
+		/// <summary>
+		/// Validates a webhook configuration.
+		/// </summary>
+		/// <param name="type">The webhook type to validate.</param>
+		/// <returns>True if the configuration is valid; otherwise, false.</returns>
+		public static bool ValidateConfig(WebhookType type) {
+			if (!_configs.TryGetValue(type, out var config))
+				return false;
+
+			// Check for required fields
+			if (string.IsNullOrEmpty(config.RequestMethod) || string.IsNullOrEmpty(config.UrlPath))
+				return false;
+
+			// Additional validation could be added here
+
+			return true;
+		}
+
+		/// <summary>
+		/// Gets all available webhook types.
+		/// </summary>
+		/// <returns>An array of all webhook types.</returns>
+		public static WebhookType[] GetAvailableTypes() {
+			var types = new WebhookType[_configs.Count];
+			_configs.Keys.CopyTo(types, 0);
+			return types;
+		}
+	}
+
+	/// <summary>
+	/// Represents the configuration for a webhook.
+	/// </summary>
+	public class WebhookConfig {
+		/// <summary>
+		/// Gets or sets the HTTP request method (e.g., "GET" or "POST").
+		/// </summary>
+		/// <remarks>
+		/// Common values: "GET", "POST", "PUT", "DELETE"
+		/// Only POST and PUT methods support sending a request body.
+		/// </remarks>
+		public string RequestMethod { get; set; }
+
+		/// <summary>
+		/// Gets or sets the URL path template with placeholders (e.g., "/minigame/{action}/{type}").
+		/// </summary>
+		/// <remarks>
+		/// Placeholders are enclosed in curly braces and will be replaced with values from:
+		/// 1. The pathParams dictionary passed to AddSendWebhook
+		/// 2. Automatically collected metadata like {playerName}, {timestamp}, etc.
+		/// </remarks>
+		public string UrlPath { get; set; }
+
+		/// <summary>
+		/// Gets or sets the display name for the webhook as shown in the settings.
+		/// </summary>
+		/// <remarks>
+		/// This should be a human-readable name that describes the webhook's purpose.
+		/// </remarks>
+		public string SettingsName { get; set; }
+	}
+}

--- a/IdlePlus/src/Utilities/WebHooks/WebhookManager.cs
+++ b/IdlePlus/src/Utilities/WebHooks/WebhookManager.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using IdlePlus.Settings;
+using Player;
+using Guilds;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.Diagnostics;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Manages the creation and processing of webhook requests.
+	/// </summary>
+	public static class WebhookManager {
+		private static readonly WebhookQueue<WebhookRequest> _webhookQueue = new WebhookRequestQueue();
+		private static readonly int MAX_RETRIES = 3;
+
+		// Methods that can have a request body
+		private static readonly HashSet<string> MethodsWithBody = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+		{
+			"POST", "PUT"
+		};
+
+		/// <summary>
+		/// Adds a webhook request to the processing queue.
+		/// </summary>
+		/// <param name="webhookType">The type of webhook to send.</param>
+		/// <param name="pathParams">Path parameters to replace in the URL template.</param>
+		/// <param name="jsonRequestData">Optional JSON data for the request body (for POST, PUT methods).</param>
+		/// <exception cref="ArgumentException">Thrown when invalid JSON data is provided.</exception>
+		/// <remarks>
+		/// This method validates settings, prepares the request and enqueues it for asynchronous processing.
+		/// Path parameters can replace placeholders in the URL template, e.g., {action} will be replaced with the value of the "action" key.
+		/// </remarks>
+		public static void AddSendWebhook(WebhookType webhookType, Dictionary<string, string> pathParams, string jsonRequestData = null) {
+			if (!TryGetEnabledConfig(webhookType, out var config)) {
+				IdleLog.Debug($"[WebhookManager] Webhook type {webhookType} is not enabled or not configured.");
+				return;
+			}
+
+			try {
+				string requestMethod = config.RequestMethod.ToUpperInvariant();
+				bool supportsBody = MethodsWithBody.Contains(requestMethod);
+
+				// For methods without body support, jsonRequestData should be null
+				if (!supportsBody && !string.IsNullOrEmpty(jsonRequestData)) {
+					jsonRequestData = null;
+				}
+
+				// Validate JSON format if data was provided
+				if (!string.IsNullOrEmpty(jsonRequestData) && !JsonHelper.IsValidJson(jsonRequestData)) {
+					IdleLog.Error($"[WebhookManager] Invalid JSON format for {webhookType}: {jsonRequestData}");
+					return; // Abort if JSON is invalid
+				}
+
+				// Collect metadata for path replacement and body if needed
+				var metadata = CollectMetadata();
+
+				// Process URL path with metadata replacements
+				string processedPath = ReplacePlaceholders(config.UrlPath, pathParams, metadata);
+
+				// Enrich with metadata if the method supports a body
+				string finalJsonData = supportsBody ? EnrichWithMetadata(jsonRequestData, pathParams, metadata) : null;
+
+				var request = new WebhookRequest {
+					WebhookType = webhookType,
+					PathParams = pathParams,
+					JsonRequestData = finalJsonData,
+					ProcessedUrlPath = processedPath,
+					RetryCount = 0
+				};
+
+				_webhookQueue.Enqueue(request);
+				IdleLog.Debug($"[WebhookManager] Request for {webhookType} added to queue with method {requestMethod}.");
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookManager] Error preparing webhook {webhookType}: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Adds a webhook request with an Il2CppSystem.Object payload to the processing queue.
+		/// </summary>
+		/// <param name="webhookType">The type of webhook to send.</param>
+		/// <param name="pathParams">Path parameters to replace in the URL template.</param>
+		/// <param name="il2cppRequestData">An Il2CppSystem.Object to be serialized to JSON.</param>
+		/// <exception cref="ArgumentException">Thrown when the object cannot be serialized to valid JSON.</exception>
+		/// <remarks>
+		/// This method converts the Il2Cpp object to JSON and then calls AddSendWebhook with the JSON data.
+		/// </remarks>
+		public static void AddSendWebhook(WebhookType webhookType, Dictionary<string, string> pathParams, Il2CppSystem.Object il2cppRequestData) {
+			try {
+				string json = JsonHelper.Serialize(il2cppRequestData);
+				if (json != null) {
+					AddSendWebhook(webhookType, pathParams, json);
+				}
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookManager] Error preparing webhook {webhookType}: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Collects metadata about the current game state.
+		/// </summary>
+		/// <returns>A dictionary containing metadata about the player, game mode, clan, etc.</returns>
+		private static Dictionary<string, string> CollectMetadata() {
+			var metadata = new Dictionary<string, string>();
+
+			// Player information - using null conditional and null coalescing operators
+			metadata["playerName"] = PlayerData.Instance?.Username ?? "Unknown";
+			metadata["gameMode"] = PlayerData.Instance?.GameMode.ToString() ?? "Unknown";
+
+			// Clan information - chain of null conditional operators
+			metadata["clanName"] = GuildManager.Instance?.OurGuild?.Name ?? "None";
+
+			// Unix Timestamp (seconds since 1/1/1970)
+			var unixTimestamp = (int)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
+			metadata["timestamp"] = unixTimestamp.ToString();
+
+			// Client version
+			metadata["clientVersion"] = IdlePlus.ModVersion;
+
+			return metadata;
+		}
+
+		/// <summary>
+		/// Enriches the provided data with metadata.
+		/// </summary>
+		/// <param name="jsonData">The original JSON data string.</param>
+		/// <param name="pathParams">Path parameters used in the request.</param>
+		/// <param name="metadata">Collected metadata to add to the JSON.</param>
+		/// <returns>A new JSON string with the added metadata.</returns>
+		private static string EnrichWithMetadata(string jsonData, Dictionary<string, string> pathParams, Dictionary<string, string> metadata) {
+			// Parse existing JSON data or create new object
+			JObject payload = !string.IsNullOrEmpty(jsonData) ? JObject.Parse(jsonData) : new JObject();
+
+			// Add metadata
+			var metadataObj = new JObject();
+			foreach (var item in metadata) {
+				metadataObj[item.Key] = new JValue(item.Value);
+			}
+			payload["metadata"] = metadataObj;
+
+			// Add path parameters if not already present
+			if (payload["params"] == null && pathParams?.Count > 0) {
+				var paramsObj = new JObject();
+				foreach (var param in pathParams) {
+					paramsObj[param.Key] = new JValue(param.Value);
+				}
+				payload["params"] = paramsObj;
+			}
+
+			return payload.ToString(Formatting.None);
+		}
+
+		/// <summary>
+		/// Replaces placeholders in the URL path with values from pathParams and metadata.
+		/// </summary>
+		/// <param name="urlPath">The URL path template with placeholders.</param>
+		/// <param name="pathParams">The path parameters to replace placeholders.</param>
+		/// <param name="metadata">Additional metadata that can be used for replacements.</param>
+		/// <returns>The processed URL path with placeholders replaced.</returns>
+		private static string ReplacePlaceholders(string urlPath, Dictionary<string, string> pathParams, Dictionary<string, string> metadata) {
+			string result = urlPath;
+
+			// Create a merged dictionary with pathParams taking precedence over metadata
+			var replacements = new Dictionary<string, string>(metadata);
+
+			// Add path parameters (will overwrite any metadata with the same key)
+			if (pathParams != null) {
+				foreach (var param in pathParams) {
+					replacements[param.Key] = param.Value;
+				}
+			}
+
+			// Replace all placeholders in one pass
+			foreach (var replacement in replacements) {
+				result = result.Replace($"{{{replacement.Key}}}", Uri.EscapeDataString(replacement.Value));
+			}
+
+			return result;
+		}
+
+		/// <summary>
+		/// Internal queue handler for webhook requests.
+		/// </summary>
+		private class WebhookRequestQueue : WebhookQueue<WebhookRequest> {
+			protected override async Task ProcessItemAsync(WebhookRequest request) {
+				await ProcessWebhookRequest(request);
+			}
+		}
+
+		/// <summary>
+		/// Processes a webhook request, handling retries and error cases.
+		/// </summary>
+		/// <param name="request">The webhook request to process.</param>
+		private static async Task ProcessWebhookRequest(WebhookRequest request) {
+			var stopwatch = Stopwatch.StartNew();
+			WebhookMetrics.RegisterStart(request.WebhookType);
+			bool success = false;
+
+			try {
+				var config = WebhookConfigProvider.GetConfig(request.WebhookType);
+				if (config == null || !IsWebhookEnabled(request.WebhookType)) {
+					IdleLog.Error($"[WebhookManager] Configuration for {request.WebhookType} not found or disabled.");
+					return;
+				}
+
+				string baseUrl = ModSettings.Hooks.BackendHookServer.Value;
+				string fullUrl = HttpService.Instance.BuildFullUrl(baseUrl, request.ProcessedUrlPath);
+				string requestMethod = config.RequestMethod;
+
+				success = await HttpService.Instance.SendRequestAsync(
+					fullUrl,
+					requestMethod,
+					request.JsonRequestData
+				);
+
+				if (!success && request.RetryCount < MAX_RETRIES) {
+					// Retry logic
+					request.RetryCount++;
+					IdleLog.Error($"[WebhookManager] Retry {request.RetryCount}/{MAX_RETRIES} for {request.WebhookType}");
+
+					// Wait before retrying (exponential backoff)
+					int delayMs = 500 * (int)Math.Pow(2, request.RetryCount);
+					await Task.Delay(delayMs);
+
+					// Re-queue the request
+					_webhookQueue.Enqueue(request);
+				} else if (!success) {
+					IdleLog.Error($"[WebhookManager] Maximum retries reached for {request.WebhookType}");
+				} else {
+					IdleLog.Info($"[WebhookManager] Successfully processed webhook {request.WebhookType}");
+				}
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookManager] Error processing webhook: {ex.Message}");
+			} finally {
+				stopwatch.Stop();
+				WebhookMetrics.RegisterCompletion(request.WebhookType, success, stopwatch.ElapsedMilliseconds, request.RetryCount);
+			}
+		}
+
+		/// <summary>
+		/// Checks if a webhook type is enabled in the settings.
+		/// </summary>
+		/// <param name="webhookType">The webhook type to check.</param>
+		/// <returns>True if the webhook is enabled; otherwise, false.</returns>
+		private static bool IsWebhookEnabled(WebhookType webhookType) {
+			return ModSettings.Hooks.WebhookToggles.TryGetValue(webhookType, out var toggle) && toggle.Value;
+		}
+
+		/// <summary>
+		/// Tries to get the configuration for an enabled webhook type.
+		/// </summary>
+		/// <param name="webhookType">The webhook type to get configuration for.</param>
+		/// <param name="config">When this method returns, contains the webhook configuration if found; otherwise, null.</param>
+		/// <returns>True if the webhook type is enabled and has valid configuration; otherwise, false.</returns>
+		private static bool TryGetEnabledConfig(WebhookType webhookType, out WebhookConfig config) {
+			config = WebhookConfigProvider.GetConfig(webhookType);
+			return config != null && IsWebhookEnabled(webhookType);
+		}
+
+		/// <summary>
+		/// Data class for webhook requests.
+		/// </summary>
+		public class WebhookRequest {
+			/// <summary>The type of webhook to send.</summary>
+			public WebhookType WebhookType;
+
+			/// <summary>Path parameters for URL template substitution.</summary>
+			public Dictionary<string, string> PathParams;
+
+			/// <summary>JSON data for the request body.</summary>
+			public string JsonRequestData;
+
+			/// <summary>The processed URL path with placeholders replaced.</summary>
+			public string ProcessedUrlPath;
+
+			/// <summary>Current retry count for this request.</summary>
+			public int RetryCount;
+		}
+
+		/// <summary>
+		/// Gets the number of webhook requests currently in the queue.
+		/// </summary>
+		/// <returns>The number of queued requests.</returns>
+		public static int GetQueuedRequestCount() {
+			return _webhookQueue.Count;
+		}
+
+		/// <summary>
+		/// Checks if a webhook type is enabled in the settings.
+		/// </summary>
+		/// <param name="webhookType">The webhook type to check.</param>
+		/// <returns>True if the webhook is enabled; otherwise, false.</returns>
+		public static bool IsWebhookTypeEnabled(WebhookType webhookType) {
+			return ModSettings.Hooks.WebhookToggles.TryGetValue(webhookType, out var toggle) && toggle.Value;
+		}
+	}
+
+	/// <summary>
+	/// Provides performance metrics for webhook processing.
+	/// </summary>
+	public static class WebhookMetrics {
+		private static readonly object _lockObject = new object();
+		private static int _totalWebhooksSent = 0;
+		private static int _totalWebhooksSucceeded = 0;
+		private static int _totalWebhooksFailed = 0;
+		private static readonly Dictionary<WebhookType, int> _countByType = new Dictionary<WebhookType, int>();
+		private static readonly Dictionary<WebhookType, long> _totalProcessingTimeByType = new Dictionary<WebhookType, long>();
+		private static readonly Dictionary<WebhookType, int> _retryCountByType = new Dictionary<WebhookType, int>();
+
+		/// <summary>
+		/// Registers the start of a webhook processing operation.
+		/// </summary>
+		/// <param name="type">The webhook type being processed.</param>
+		public static void RegisterStart(WebhookType type) {
+			lock (_lockObject) {
+				_totalWebhooksSent++;
+
+				if (!_countByType.ContainsKey(type))
+					_countByType[type] = 0;
+				_countByType[type]++;
+			}
+		}
+
+		/// <summary>
+		/// Registers the completion of a webhook processing operation.
+		/// </summary>
+		/// <param name="type">The webhook type that was processed.</param>
+		/// <param name="success">Whether the processing was successful.</param>
+		/// <param name="processingTimeMs">The processing time in milliseconds.</param>
+		/// <param name="retryCount">The number of retries that were needed.</param>
+		public static void RegisterCompletion(WebhookType type, bool success, long processingTimeMs, int retryCount) {
+			lock (_lockObject) {
+				if (success)
+					_totalWebhooksSucceeded++;
+				else
+					_totalWebhooksFailed++;
+
+				if (!_totalProcessingTimeByType.ContainsKey(type))
+					_totalProcessingTimeByType[type] = 0;
+				_totalProcessingTimeByType[type] += processingTimeMs;
+
+				if (!_retryCountByType.ContainsKey(type))
+					_retryCountByType[type] = 0;
+				_retryCountByType[type] += retryCount;
+			}
+		}
+
+		/// <summary>
+		/// Gets a report with performance metrics.
+		/// </summary>
+		/// <returns>A string containing the performance report.</returns>
+		public static string GetReport() {
+			lock (_lockObject) {
+				var report = new System.Text.StringBuilder();
+				report.AppendLine("=== Webhook Performance Report ===");
+				report.AppendLine($"Total Webhooks: {_totalWebhooksSent}");
+				report.AppendLine($"Success Rate: {(_totalWebhooksSent > 0 ? (_totalWebhooksSucceeded * 100.0 / _totalWebhooksSent).ToString("F2") : "0.00")}%");
+				report.AppendLine();
+				report.AppendLine("By Type:");
+
+				foreach (var type in _countByType.Keys) {
+					int count = _countByType[type];
+					long totalTime = _totalProcessingTimeByType.ContainsKey(type) ? _totalProcessingTimeByType[type] : 0;
+					int retries = _retryCountByType.ContainsKey(type) ? _retryCountByType[type] : 0;
+
+					report.AppendLine($"  {type}:");
+					report.AppendLine($"    Count: {count}");
+					report.AppendLine($"    Avg Time: {(count > 0 ? (totalTime / count).ToString() : "0")}ms");
+					report.AppendLine($"    Retries: {retries}");
+				}
+
+				return report.ToString();
+			}
+		}
+
+		/// <summary>
+		/// Resets all statistics.
+		/// </summary>
+		public static void Reset() {
+			lock (_lockObject) {
+				_totalWebhooksSent = 0;
+				_totalWebhooksSucceeded = 0;
+				_totalWebhooksFailed = 0;
+				_countByType.Clear();
+				_totalProcessingTimeByType.Clear();
+				_retryCountByType.Clear();
+			}
+		}
+	}
+}

--- a/IdlePlus/src/Utilities/WebHooks/WebhookQueue.cs
+++ b/IdlePlus/src/Utilities/WebHooks/WebhookQueue.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Generic queue for asynchronous processing of items with parallel execution.
+	/// </summary>
+	/// <typeparam name="T">The type of items in the queue.</typeparam>
+	public abstract class WebhookQueue<T> {
+		private readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
+		private readonly SemaphoreSlim _processingLock = new SemaphoreSlim(1, 1);
+		private readonly SemaphoreSlim _parallelismLimiter;
+		private volatile bool _isProcessing;
+		private readonly int _maxConsecutiveErrors;
+		private int _consecutiveErrors;
+		private CancellationTokenSource _cancellationTokenSource;
+		private readonly List<Task> _runningTasks = new List<Task>();
+		private readonly object _tasksLock = new object();
+
+		/// <summary>
+		/// Gets the current number of active parallel tasks.
+		/// </summary>
+		public int ActiveTasksCount {
+			get {
+				lock (_tasksLock) {
+					// Count only non-completed tasks
+					return _runningTasks.Count;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets the number of items in the queue.
+		/// </summary>
+		public int Count => _queue.Count;
+
+		/// <summary>
+		/// Initializes a new instance of the WebhookQueue class.
+		/// </summary>
+		/// <param name="maxParallelTasks">Maximum number of parallel tasks to run.</param>
+		/// <param name="maxConsecutiveErrors">Maximum number of consecutive errors before pausing processing.</param>
+		protected WebhookQueue(int maxParallelTasks = 10, int maxConsecutiveErrors = 5) {
+			_parallelismLimiter = new SemaphoreSlim(maxParallelTasks, maxParallelTasks);
+			_maxConsecutiveErrors = maxConsecutiveErrors;
+			_cancellationTokenSource = new CancellationTokenSource();
+		}
+
+		/// <summary>
+		/// Adds an item to the queue for processing.
+		/// </summary>
+		/// <param name="item">The item to enqueue.</param>
+		public void Enqueue(T item) {
+			if (item == null) {
+				IdleLog.Error("[WebhookQueue] Cannot enqueue null item");
+				return;
+			}
+
+			_queue.Enqueue(item);
+			IdleLog.Debug($"[WebhookQueue] Item added to queue. Queue size: {_queue.Count}");
+			StartProcessingIfNotRunning();
+		}
+
+		/// <summary>
+		/// Starts the queue processor if it is not already running.
+		/// </summary>
+		private async void StartProcessingIfNotRunning() {
+			bool shouldProcess = false;
+
+			try {
+				await _processingLock.WaitAsync();
+
+				if (_isProcessing) return;
+				_isProcessing = true;
+				shouldProcess = true;
+
+				// Reset cancellation token if it was cancelled
+				if (_cancellationTokenSource.IsCancellationRequested) {
+					_cancellationTokenSource.Dispose();
+					_cancellationTokenSource = new CancellationTokenSource();
+				}
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookQueue] Error in StartProcessingIfNotRunning: {ex.Message}");
+				_isProcessing = false;
+			} finally {
+				_processingLock.Release();
+			}
+
+			if (shouldProcess) {
+				try {
+					await ProcessQueueAsync(_cancellationTokenSource.Token);
+				} catch (TaskCanceledException) {
+					IdleLog.Debug("[WebhookQueue] Queue processing was cancelled");
+				} catch (Exception ex) {
+					IdleLog.Error($"[WebhookQueue] Unhandled error in queue processing: {ex.Message}");
+				}
+
+				await _processingLock.WaitAsync();
+				try {
+					_isProcessing = false;
+				} finally {
+					_processingLock.Release();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Continuously processes the queue asynchronously with parallel execution.
+		/// </summary>
+		/// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+		private async Task ProcessQueueAsync(CancellationToken cancellationToken) {
+			IdleLog.Debug("[WebhookQueue] Started processing queue in parallel mode");
+
+			try {
+				while (!cancellationToken.IsCancellationRequested) {
+					// Check if the queue is empty
+					if (_queue.IsEmpty) {
+						// Wait until all running tasks are completed
+						if (ActiveTasksCount > 0) {
+							IdleLog.Debug($"[WebhookQueue] Queue empty, waiting for {ActiveTasksCount} tasks to complete");
+							await Task.Delay(100, cancellationToken);
+							continue;
+						} else {
+							// No items and no running tasks - we're done
+							IdleLog.Debug("[WebhookQueue] Queue processing complete");
+							break;
+						}
+					}
+
+					// Too many consecutive errors - take a pause
+					if (_consecutiveErrors >= _maxConsecutiveErrors) {
+						IdleLog.Error($"[WebhookQueue] Pausing processing after {_consecutiveErrors} consecutive errors. Will retry in 30 seconds.");
+						try {
+							await Task.Delay(30000, cancellationToken); // Wait 30 seconds
+						} catch (TaskCanceledException) {
+							break;
+						}
+						_consecutiveErrors = 0;  // Reset the counter and try again
+					}
+
+					// Try to take an element from the queue
+					if (_queue.TryDequeue(out var item)) {
+						// Wait until a slot for a new parallel task is available
+						await _parallelismLimiter.WaitAsync(cancellationToken);
+
+						// Start processing as a separate task
+						var processingTask = Task.Run(async () => {
+							try {
+								await ProcessItemAsync(item);
+								Interlocked.Exchange(ref _consecutiveErrors, 0); // Thread-safe reset
+								IdleLog.Debug($"[WebhookQueue] Task completed successfully, active tasks: {ActiveTasksCount}");
+							} catch (Exception ex) {
+								Interlocked.Increment(ref _consecutiveErrors);
+								IdleLog.Error($"[WebhookQueue] Error processing item: {ex.Message}");
+							} finally {
+								// Release the parallel slot
+								_parallelismLimiter.Release();
+							}
+						}, cancellationToken);
+
+						// Add a continuation to remove the task from the list
+						var task = processingTask.ContinueWith(t => {
+							lock (_tasksLock) {
+								_runningTasks.Remove(processingTask);
+							}
+						}, TaskContinuationOptions.ExecuteSynchronously);
+
+						// Add the task to the list of active tasks
+						lock (_tasksLock) {
+							_runningTasks.Add(processingTask);
+							IdleLog.Debug($"[WebhookQueue] Started new task, active tasks: {_runningTasks.Count}");
+						}
+					} else {
+						// Wait briefly if we couldn't get an item
+						await Task.Delay(50, cancellationToken);
+					}
+				}
+			} finally {
+				// Wait for completion of all running tasks
+				Task[] tasksToWaitFor;
+				lock (_tasksLock) {
+					tasksToWaitFor = _runningTasks.ToArray();
+					_runningTasks.Clear();  // Clear the list to prevent memory leaks
+				}
+
+				if (tasksToWaitFor.Length > 0) {
+					IdleLog.Debug($"[WebhookQueue] Waiting for {tasksToWaitFor.Length} tasks to complete during cleanup");
+					try {
+						// Use a timeout to avoid hanging
+						var waitTask = Task.WhenAll(tasksToWaitFor);
+						var completedTask = await Task.WhenAny(waitTask, Task.Delay(2000));
+
+						if (completedTask != waitTask) {
+							IdleLog.Warn("[WebhookQueue] Some tasks did not complete within timeout period during cleanup");
+						}
+					} catch (Exception ex) {
+						IdleLog.Error($"[WebhookQueue] Error waiting for tasks during cleanup: {ex.Message}");
+					}
+				}
+
+				IdleLog.Debug("[WebhookQueue] Queue processing finished and resources cleaned up");
+			}
+		}
+
+		/// <summary>
+		/// Cancels all ongoing queue processing.
+		/// </summary>
+		public void CancelProcessing() {
+			try {
+				_cancellationTokenSource.Cancel();
+				IdleLog.Debug("[WebhookQueue] Processing cancelled");
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookQueue] Error cancelling processing: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Cancels all ongoing queue processing and waits until all tasks are completed.
+		/// </summary>
+		/// <param name="timeoutMs">Timeout in milliseconds for waiting on task completion.</param>
+		/// <returns>A Task representing the asynchronous operation.</returns>
+		public async Task CancelAndWaitAsync(int timeoutMs = 5000) {
+			try {
+				// Cancel the processing
+				_cancellationTokenSource?.Cancel();
+				IdleLog.Debug("[WebhookQueue] Processing cancelled, waiting for tasks to complete");
+
+				// Wait for all active tasks to complete
+				Task[] tasksToWaitFor;
+				lock (_tasksLock) {
+					tasksToWaitFor = _runningTasks.ToArray();
+				}
+
+				if (tasksToWaitFor.Length > 0) {
+					// Use a timeout in case tasks get stuck
+					var waitTask = Task.WhenAll(tasksToWaitFor);
+					var completedTask = await Task.WhenAny(waitTask, Task.Delay(timeoutMs));
+
+					if (completedTask != waitTask) {
+						IdleLog.Warn($"[WebhookQueue] Timeout waiting for {tasksToWaitFor.Length} tasks to complete");
+					} else {
+						IdleLog.Debug($"[WebhookQueue] All {tasksToWaitFor.Length} tasks completed successfully");
+					}
+				}
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookQueue] Error during cancel and wait: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Releases all resources used by the WebhookQueue.
+		/// </summary>
+		public void Dispose() {
+			try {
+				CancelProcessing();
+
+				// Wait briefly to allow running tasks to terminate
+				Task.Delay(100).Wait();
+
+				// Dispose of semaphores
+				_processingLock?.Dispose();
+				_parallelismLimiter?.Dispose();
+
+				// Dispose of CancellationTokenSource
+				_cancellationTokenSource?.Dispose();
+
+				IdleLog.Debug("[WebhookQueue] Resources disposed properly");
+			} catch (Exception ex) {
+				IdleLog.Error($"[WebhookQueue] Error during disposal: {ex.Message}");
+			}
+		}
+
+		/// <summary>
+		/// Processes a single item from the queue.
+		/// </summary>
+		/// <param name="item">The item to process.</param>
+		/// <returns>A task representing the asynchronous operation.</returns>
+		protected abstract Task ProcessItemAsync(T item);
+	}
+}

--- a/IdlePlus/src/Utilities/WebHooks/WebhookTests.cs
+++ b/IdlePlus/src/Utilities/WebHooks/WebhookTests.cs
@@ -1,0 +1,157 @@
+using System.Collections.Generic;
+using System;
+
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Contains test cases for webhook functionality with support for repeated execution.
+	/// </summary>
+	public static class WebhookTests {
+		private static object _runningRepeater = null;
+		private static readonly object _repeaterLock = new object();
+
+		/// <summary>
+		/// Runs test cases for sending webhook requests once.
+		/// </summary>
+		public static void RunTests() {
+			IdleLog.Info("[WebhookTests] Starting webhook tests...");
+
+			// Test 1: Standard Minigame start event
+			IdleLog.Debug("[WebhookTests] Test 1: Minigame start event");
+			WebhookManager.AddSendWebhook(
+				WebhookType.Minigame,
+				new Dictionary<string, string>
+				{
+					{ "action", "start" },
+					{ "type", "Gathering" }
+				}
+			);
+
+			// Test 2: Minigame stop event
+			IdleLog.Debug("[WebhookTests] Test 2: Minigame stop event");
+			WebhookManager.AddSendWebhook(
+				WebhookType.Minigame,
+				new Dictionary<string, string>
+				{
+					{ "action", "stop" },
+					{ "type", "Gathering" }
+				}
+			);
+
+			// Test 3: Minigame start with JSON data
+			IdleLog.Debug("[WebhookTests] Test 3: Minigame start with JSON data");
+			string eventJson = "{\"difficulty\":\"hard\",\"duration\":180}";
+			WebhookManager.AddSendWebhook(
+				WebhookType.Minigame,
+				new Dictionary<string, string>
+				{
+					{ "action", "start" },
+					{ "type", "Gathering" }
+				},
+				eventJson
+			);
+
+			// Log statistics
+			IdleLog.Info("[WebhookTests] All webhook tests queued.");
+		}
+
+		/// <summary>
+		/// Runs a single test with the specified parameters.
+		/// </summary>
+		/// <param name="type">The webhook type to test.</param>
+		/// <param name="pathParams">The path parameters for the request.</param>
+		/// <param name="jsonData">Optional JSON data for the request body.</param>
+		public static void RunSingleTest(WebhookType type, Dictionary<string, string> pathParams, string jsonData = null) {
+			WebhookManager.AddSendWebhook(
+				type,
+				pathParams,
+				jsonData
+			);
+
+			IdleLog.Info("[WebhookTests] Single test queued.");
+		}
+
+		/// <summary>
+		/// Starts a repeating task that runs webhook tests at the specified interval.
+		/// </summary>
+		/// <param name="intervalSeconds">The interval in seconds between test runs.</param>
+		/// <returns>True if the repeater was started; false if it's already running.</returns>
+		public static bool StartTestRepeater(int intervalSeconds = 5) {
+			lock (_repeaterLock) {
+				if (_runningRepeater != null) {
+					IdleLog.Info($"[WebhookTests] Test repeater is already running");
+					return false;
+				}
+
+				IdleLog.Info($"[WebhookTests] Starting test repeater with {intervalSeconds}s interval");
+
+				_runningRepeater = IdleTasks.Repeat(0, intervalSeconds, task => {
+					RunTests();
+					IdleLog.Info("[WebhookTests] Test run complete.");
+				});
+
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Stops the currently running test repeater if it exists.
+		/// </summary>
+		/// <returns>True if a repeater was stopped; false if none was running.</returns>
+		public static bool StopTestRepeater() {
+			lock (_repeaterLock) {
+				if (_runningRepeater == null) {
+					IdleLog.Info("[WebhookTests] No test repeater is currently running");
+					return false;
+				}
+
+				IdleLog.Info("[WebhookTests] Stopping test repeater");
+
+				try {
+					var idleTask = _runningRepeater as IdleTasks.IdleTask;
+					idleTask.Cancel();
+					IdleLog.Info("[WebhookTests] Stopped repeater using IdleTask.Cancel() method");
+
+				} catch (Exception ex) {
+					IdleLog.Error($"[WebhookTests] Error stopping repeater: {ex.Message}");
+					IdleLog.Debug($"[WebhookTests] Repeater type: {_runningRepeater.GetType().FullName}");
+				}
+
+				_runningRepeater = null;
+				return true;
+			}
+		}
+
+		/// <summary>
+		/// Checks if the test repeater is currently running.
+		/// </summary>
+		/// <returns>True if the repeater is running; otherwise, false.</returns>
+		public static bool IsRepeaterRunning() {
+			lock (_repeaterLock) {
+				return _runningRepeater != null;
+			}
+		}
+
+		/// <summary>
+		/// Gets the current interval of the running repeater, or 0 if none is running.
+		/// </summary>
+		/// <returns>The interval in seconds, or 0 if no repeater is running.</returns>
+		public static int GetRepeaterInterval() {
+			lock (_repeaterLock) {
+				if (_runningRepeater == null)
+					return 0;
+
+				try {
+					// Use reflection to read the RepeatTime property
+					var repeatTimeProperty = _runningRepeater.GetType().GetProperty("RepeatTime");
+					if (repeatTimeProperty != null) {
+						return (int)repeatTimeProperty.GetValue(_runningRepeater);
+					}
+				} catch (Exception ex) {
+					IdleLog.Error($"[WebhookTests] Error getting repeater interval: {ex.Message}");
+				}
+
+				return 0;
+			}
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ the experience with features like *Edit Offer* in the Player Market, *Market Val
 - **Enhanced item tooltip**: Item tooltips that display equipment stats, which items a scroll can be used on, and more.
 - **Enhanced inventory stats**: A cleaner stats panel in your inventory.
 - **Enhanced chat commands**: Chat commands using Brigadier, with tab completion and user feedback.
+- **[Webhooks for developers](./WEBHOOKS.md)**: Integrate with external systems via webhooks to receive real-time notifications about in-game events.
 - **And much more planned!**
 
 ## Installation

--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -1,0 +1,130 @@
+# Webhooks for Backend Developers
+
+IdlePlus supports webhooks to integrate with external systems. This allows server-side applications to receive real-time notifications about in-game events.
+
+## Configuration
+
+To use webhooks:
+
+1. Navigate to the IdlePlus settings tab in the game settings menu
+2. Under "WebHooks" section:
+   - Set your backend URL (must start with http:// or https://)
+   - Configure a security token (will be sent as Authorization header)
+   - Enable specific webhook types you want to use
+
+## Technical Details
+
+- Each webhook type has a predefined URL path and HTTP method
+- URL paths support placeholders like `{action}` and `{type}` that get replaced with actual values
+- For POST and PUT requests, metadata is automatically included in the JSON body:
+  ```json
+  {
+    "metadata": {
+      "playerName": "PlayerUsername",
+      "gameMode": "Default",
+      "clanName": "PlayerClan",
+      "timestamp": "1743177263",
+      "clientVersion": "1.4.2"
+    },
+    "params": {
+      // Original parameters passed to the webhook
+    }
+    // Original request data (if any)
+  }
+  ```
+- The Authorization header contains the security token you configured in settings
+
+## Developer Commands
+
+When developer tools are enabled, you can use these commands for testing webhooks:
+
+```
+/dev webhook run-test                - Run predefined webhook tests
+/dev webhook show-metrics            - Display performance metrics
+/dev webhook run-test-repeater       - Start automatically running tests at intervals
+/dev webhook stop-test-repeater      - Stop automatic test runner
+/dev webhook status-test-repeater    - Show webhook configuration status
+```
+
+## Available Webhook Types
+
+Currently, the following webhook types are implemented:
+
+### Minigame Events
+
+Triggered when a player starts or stops minigame/clan events.
+
+- **Method**: POST
+- **Path**: `/minigame/{action}/{type}`
+- **Path Parameters**:
+  - `action`: "start" or "stop"
+  - `type`: The type of minigame (e.g., "Gathering", "Crafting", "CombatBigExpDaily")
+
+#### Example Requests
+
+##### Start Gathering Event
+
+```
+POST /minigame/start/Gathering
+Headers:
+  Authorization: your-configured-token
+  Content-Type: application/json; charset=utf-8
+
+Body:
+{
+  "metadata": {
+    "playerName": "PlayerName",
+    "gameMode": "Default",
+    "clanName": "ClanName",
+    "timestamp": "1743177263",
+    "clientVersion": "1.4.2"
+  },
+  "params": { 
+    "action": "start", 
+    "type": "Gathering" 
+  }
+}
+```
+
+##### Stop Combat Big Loot Daily Event
+
+```
+POST /minigame/stop/CombatBigLootDaily
+Headers:
+  Authorization: your-configured-token
+  Content-Type: application/json; charset=utf-8
+
+Body:
+{
+  "metadata": {
+    "playerName": "PlayerName",
+    "gameMode": "Default",
+    "clanName": "ClanName",
+    "timestamp": "1743178632",
+    "clientVersion": "1.4.2"
+  },
+  "params": { 
+    "action": "stop", 
+    "type": "CombatBigLootDaily" 
+  }
+}
+```
+
+### Known Event Types
+
+The following event types have been observed:
+- `Gathering`
+- `Crafting`
+- `CombatBigExpDaily`
+- `CombatBigLootDaily`
+- `SkillingParty`
+
+## Adding Custom Webhook Types
+
+Developers can contribute additional webhook types by:
+
+1. Adding a new value to the `WebhookType` enum
+2. Configuring the new webhook in the `WebhookConfigProvider._configs` dictionary
+3. Calling `WebhookManager.AddSendWebhook()` at appropriate points in the code
+
+For implementation details, see the source code in `IdlePlus/src/Utilities/WebHooks/`.


### PR DESCRIPTION
A new webhook section has been added to the settings, allowing the configuration of a backend URL and an authentication barrier.
Two webhook options are now available via toggles:

-     Clan Events: Sends a start and stop request for each clan event.
-     Clan Event Series: Sends a start request only for the first event in a series and a stop request only if no new event starts within 2 seconds. This is especially useful for external systems to notify the user when an auto-mode event series is finished and it’s time to return to the PC.

I will test this feature more thoroughly tomorrow, and I welcome any optimization suggestions.