### PR TITLE
Add webhooks for various clan actions

### DIFF
--- a/IdlePlus/src/Patches/Guilds/ApplicationReceivedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/ApplicationReceivedPatch.cs
@@ -1,0 +1,23 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnApplicationReceived")]
+	public class OnApplicationReceived {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ReceiveGuildApplicationMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ApplicationReceived },
+					{ "player_applying", message.PlayerApplying.ToString() },
+					{ "player_total_level", message.PlayerTotalLevel.ToString() },
+					{ "message", message.Message.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/ClanActionWebhooks.cs
+++ b/IdlePlus/src/Patches/Guilds/ClanActionWebhooks.cs
@@ -1,0 +1,24 @@
+namespace IdlePlus.Utilities {
+	/// <summary>
+	/// Constants for clan action webhook strings used throughout the application.
+	/// </summary>
+	public static class ClanActionWebhooks {
+		public const string SkillingTicketReceived = "skilling-ticket-received";
+		public const string ItemsSentToVault = "items-sent-to-vault";
+		public const string ApplicationReceived = "application-received";
+		public const string DailyQuestsUpdated = "daily-quests-updated";
+		public const string MemberLoggedIn = "member-logged-in";
+		public const string MemberLoggedOut = "member-logged-out";
+		public const string MemberJoinedClan = "member-joined-clan";
+		public const string ClanBossModifierPurchased = "clan-boss-modifier-purchased";
+		public const string DailyCombatQuestProgressed = "daily-combat-quest-progressed";
+		public const string DailySkillingQuestProgressed = "daily-skilling-quest-progressed";
+		public const string ClanHousePurchased = "clan-house-purchased";
+		public const string MemberDemoted = "member-demoted";
+		public const string MemberKicked = "member-kicked";
+		public const string MemberPromoted = "member-promoted";
+		public const string MemberLeftClan = "member-left-clan";
+		public const string ClanUpgradePurchased = "clan-upgrade-purchased";
+		public const string ItemWithdrawnFromVault = "item-withdrawn-from-vault";
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/ClanBossModifierPurchasedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/ClanBossModifierPurchasedPatch.cs
@@ -1,0 +1,25 @@
+using Guilds;
+using Databases;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnClanBossModifierPurchased")]
+	public class OnClanBossModifierPurchased {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ClanBossPurchaseModifierPurchasedMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ClanBossModifierPurchased },
+					{ "boss_type", message.BossType.ToString() },
+					{ "modifier_type", message.ModifierType.ToString() },
+					{ "username", message.Username.ToString() },
+					{ "new_tier", message.NewTier.ToString() },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/DailyCombatQuestProgressedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/DailyCombatQuestProgressedPatch.cs
@@ -1,0 +1,22 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnDailyCombatQuestProgressed")]
+	public class OnDailyCombatQuestProgressed {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ProgressDailyCombatQuestMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.DailyCombatQuestProgressed },
+					{ "entity_id", message.EntityId.ToString() },
+					{ "username", message.Username.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/DailyQuestUpdatedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/DailyQuestUpdatedPatch.cs
@@ -1,0 +1,20 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnDailyQuestUpdated")]
+	public class OnDailyQuestUpdated {
+		[HarmonyPostfix]
+		public static void Postfix(Network.RefreshDailyQuestsMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.DailyQuestsUpdated },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/DailySkillingQuestProgressedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/DailySkillingQuestProgressedPatch.cs
@@ -1,0 +1,33 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+using Databases;
+using IdlePlus.API.Utility.Game;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnDailySkillingQuestProgressed")]
+	public class OnDailySkillingQuestProgressed {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ProgressDailySkillingQuestMessage message) {
+			string itemName = "unknown";
+			if (ItemDatabase.ItemList.TryGetValue(message.ItemId, out var item)) {
+				itemName = item.IdlePlus_GetLocalizedEnglishName();
+			}
+
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.DailySkillingQuestProgressed },
+					{ "item_id", message.ItemId.ToString() },
+					{ "item_name", itemName },
+					{ "amount", message.Amount.ToString() },
+					{ "original_amount", message.OriginalAmount.ToString() },
+					{ "restored_amount", message.RestoredAmount.ToString() },
+					{ "username", message.Username.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildHousePurchasedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildHousePurchasedPatch.cs
@@ -1,0 +1,20 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildHousePurchased")]
+	public class OnGuildHousePurchased {
+		[HarmonyPostfix]
+		public static void Postfix(Network.PurchaseGuildHouseMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ClanHousePurchased },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberDemotedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberDemotedPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildMemberDemoted")]
+	public class OnGuildMemberDemoted {
+		[HarmonyPostfix]
+		public static void Postfix(string playerName) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberDemoted },
+					{ "username", playerName },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberEntryPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberEntryPatch.cs
@@ -3,7 +3,7 @@ using HarmonyLib;
 using IdlePlus.TexturePack;
 
 namespace IdlePlus.Patches.Guilds {
-	
+
 	[HarmonyPatch(typeof(GuildMemberEntry))]
 	public class GuildMemberEntryPatch {
 
@@ -12,17 +12,17 @@ namespace IdlePlus.Patches.Guilds {
 		private static void PrefixSetup(GuildMemberEntry __instance, GameMode gameMode, bool premium,
 			bool premiumPlus) {
 			if (TexturePackManager.CurrentPack == null) return;
-			
+
 			var pack = TexturePackManager.CurrentPack;
 			var ironmanIcon = __instance._ironmanIconGO;
 			var premiumIcon = __instance._premiumIconGO;
 			var gildedIcon = __instance._premiumPlusIconGO;
-			
-			if (gameMode == GameMode.Ironman) 
+
+			if (gameMode == GameMode.Ironman)
 				pack.TryApplyMiscSprite("ironman_icon", ironmanIcon);
-			else if (gameMode == GameMode.GroupIronman) 
+			else if (gameMode == GameMode.GroupIronman)
 				pack.TryApplyMiscSprite("group_ironman_icon", ironmanIcon);
-			
+
 			if (premium) pack.TryApplyMiscSprite("premium_icon", premiumIcon);
 			if (premiumPlus) pack.TryApplyMiscSprite("gilded_icon", gildedIcon);
 		}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberKickedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberKickedPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildMemberKicked")]
+	public class OnGuildMemberKicked {
+		[HarmonyPostfix]
+		public static void Postfix(string playerName) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberKicked },
+					{ "username", playerName },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberLoggedInPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberLoggedInPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildMemberLoggedIn")]
+	public class OnGuildMemberLoggedIn {
+		[HarmonyPostfix]
+		public static void Postfix(string guildMemberName) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberLoggedIn },
+					{ "username", guildMemberName }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberLoggedOutPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberLoggedOutPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildMemberLoggedOut")]
+	public class OnGuildMemberLoggedOut {
+		[HarmonyPostfix]
+		public static void Postfix(string guildMemberName) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberLoggedOut },
+					{ "username", guildMemberName }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/GuildMemberPromotedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/GuildMemberPromotedPatch.cs
@@ -1,0 +1,22 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnGuildMemberPromoted")]
+	public class OnGuildMemberPromoted {
+		[HarmonyPostfix]
+		public static void Postfix(Network.GuildMemberPromotedMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberPromoted },
+					{ "username", message.PlayerName },
+					{ "new_rank", message.NewRank.ToString() },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/ItemSentToVaultPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/ItemSentToVaultPatch.cs
@@ -1,0 +1,33 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+using Databases;
+using IdlePlus.API.Utility.Game;
+using IdlePlus.Utilities.Helpers;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnItemSentToVault")]
+	public class OnItemSentToVault {
+		[HarmonyPostfix]
+		public static void Postfix(Network.SendItemToGuildMessage message) {
+			string itemName = "unknown";
+			if (ItemDatabase.ItemList.TryGetValue(message.ItemId, out var item)) {
+				itemName = item.IdlePlus_GetLocalizedEnglishName();
+			}
+
+			var items = new Il2CppSystem.Collections.Generic.Dictionary<int, int>();
+			items[message.ItemId] = message.ItemAmount;
+
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ItemsSentToVault },
+					{ "items", JsonHelper.Serialize(items) },
+					{ "username", message.Username.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/ItemWithdrawnFromVaultPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/ItemWithdrawnFromVaultPatch.cs
@@ -1,0 +1,31 @@
+using Guilds;
+using HarmonyLib;
+using Databases;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+using IdlePlus.API.Utility.Game;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnItemWithdrawnFromVault")]
+	public class OnItemWithdrawnFromVault {
+		[HarmonyPostfix]
+		public static void Postfix(Network.WithdrawItemFromGuildMessage message) {
+			string itemName = "unknown";
+			if (ItemDatabase.ItemList.TryGetValue(message.ItemId, out var item)) {
+				itemName = item.IdlePlus_GetLocalizedEnglishName();
+			}
+
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ItemWithdrawnFromVault },
+					{ "username", message.Username.ToString() },
+					{ "item_id", message.ItemId.ToString() },
+					{ "item_name", itemName },
+					{ "amount", message.ItemAmount.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/ItemsSentToVaultPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/ItemsSentToVaultPatch.cs
@@ -1,0 +1,23 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using IdlePlus.Utilities.Helpers;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnItemsSentToVault")]
+	public class OnItemsSentToVault {
+		[HarmonyPostfix]
+		public static void Postfix(Network.SendItemsToGuildMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ItemsSentToVault },
+					{ "items", JsonHelper.Serialize(message.Items) },
+					{ "username", message.Username.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/PlayerJoinedGuildPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/PlayerJoinedGuildPatch.cs
@@ -1,0 +1,22 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using IdlePlus.Utilities.Helpers;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnJoinedGuild")]
+	public class OnJoinedGuild {
+		[HarmonyPostfix]
+		public static void Postfix(Network.PlayerJoinedGuildMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberJoinedClan },
+					{ "username", message.PlayerJoining.ToString() },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/PlayerLeftGuildPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/PlayerLeftGuildPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnPlayerLeftGuild")]
+	public class OnPlayerLeftGuild {
+		[HarmonyPostfix]
+		public static void Postfix(string playerName) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.MemberLeftClan },
+					{ "username", playerName }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/SkillingTicketReceivedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/SkillingTicketReceivedPatch.cs
@@ -1,0 +1,23 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnSkillingTicketReceived")]
+	public class OnSkillingTicketReceived {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ReceiveSkillingTicketMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.SkillingTicketReceived },
+					{ "skill", message.Skill.ToString() },
+					{ "amount", message.Amount.ToString() },
+					{ "username", message.Username.ToString() }
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Patches/Guilds/UpgradePurchasedPatch.cs
+++ b/IdlePlus/src/Patches/Guilds/UpgradePurchasedPatch.cs
@@ -1,0 +1,21 @@
+using Guilds;
+using HarmonyLib;
+using IdlePlus.Utilities;
+using System.Collections.Generic;
+
+namespace IdlePlus.Patches.Guilds {
+	[HarmonyPatch(typeof(GuildListener), "OnUpgradePurchased")]
+	public class OnUpgradePurchased {
+		[HarmonyPostfix]
+		public static void Postfix(Network.ClanUpgradePurchasedMessage message) {
+			WebhookManager.AddSendWebhook(
+				WebhookType.ClanAction,
+				new Dictionary<string, string>
+				{
+					{ "action", ClanActionWebhooks.ClanUpgradePurchased },
+					{ "upgrade_type", message.Upgrade.ToString() },
+				}
+			);
+		}
+	}
+}

--- a/IdlePlus/src/Utilities/WebHooks/WebhookConfigProvider.cs
+++ b/IdlePlus/src/Utilities/WebHooks/WebhookConfigProvider.cs
@@ -10,8 +10,8 @@ namespace IdlePlus.Utilities {
 	/// </remarks>
 	public enum WebhookType {
 		/// <summary>Minigame/clan event webhooks.</summary>
-		Minigame
-
+		Minigame,
+		ClanAction
 		// When adding a new webhook type:
 		// 1. Add it here as a new enum value
 		// 2. Add its configuration to the _configs dictionary in WebhookConfigProvider
@@ -50,6 +50,13 @@ namespace IdlePlus.Utilities {
 					RequestMethod = "POST",
 					UrlPath = "/minigame/{action}/{type}",
 					SettingsName = "Minigames (Clan Events)"
+				}
+			},
+			{
+				WebhookType.ClanAction, new WebhookConfig {
+					RequestMethod = "POST",
+					UrlPath = "/clan",
+					SettingsName = "Clan Actions (Application received, new skill ticket, etc)"
 				}
 			}
             

--- a/WEBHOOKS.md
+++ b/WEBHOOKS.md
@@ -119,6 +119,88 @@ The following event types have been observed:
 - `CombatBigLootDaily`
 - `SkillingParty`
 
+### Clan Action Webhooks
+
+Clan action webhooks are triggered by various clan-related activities and provide real-time notifications about clan activities.
+
+- **Method**: POST
+- **Path**: `/clan`
+- **Body Parameters**: Varies by action type (see individual actions below)
+
+#### Available Clan Actions
+
+The following clan action webhooks are implemented:
+
+##### Member Management
+- **`member-logged-in`** - Triggered when a clan member logs into the game
+  - Parameters: `username`
+- **`member-logged-out`** - Triggered when a clan member logs out of the game
+  - Parameters: `username`
+- **`member-joined-clan`** - Triggered when a player joins the clan
+  - Parameters: `username`
+- **`member-left-clan`** - Triggered when a player leaves the clan
+  - Parameters: `username`
+- **`member-promoted`** - Triggered when a clan member is promoted
+  - Parameters: `new_rank`, `username`
+- **`member-demoted`** - Triggered when a clan member is demoted
+  - Parameters: `username`
+- **`member-kicked`** - Triggered when a clan member is kicked from the clan
+  - Parameters: `username`
+
+##### Clan Applications
+- **`application-received`** - Triggered when a player applies to join the clan
+  - Parameters: `player_applying`, `player_total_level`, `message`
+
+##### Clan Resources & Items
+- **`skilling-ticket-received`** - Triggered when a clan member receives a skilling ticket
+  - Parameters: `skill`, `amount`, `username`
+- **`items-sent-to-vault`** - Triggered when a clan member sends multiple items to the clan vault
+  - Parameters: `items` (serialized JSON array `{"<item_id>": <item_amount>}`), `username`
+- **`item-withdrawn-from-vault`** - Triggered when a clan member withdraws an item from the clan vault
+  - Parameters: `item_id`, `item_name`, `amount`, `username`
+
+##### Clan Quests & Progress
+- **`daily-quests-updated`** - Triggered when daily quests are refreshed
+  - Parameters: None
+- **`daily-combat-quest-progressed`** - Triggered when a clan member progresses a daily combat quest
+  - Parameters: `entity_id`, `username`
+- **`daily-skilling-quest-progressed`** - Triggered when a clan member progresses a daily skilling quest
+  - Parameters: `item_id`, `item_name`, `amount`, `original_amount`, `restored_amount`, `username`
+
+##### Clan Purchases & Upgrades
+- **`clan-boss-modifier-purchased`** - Triggered when a clan boss modifier is purchased
+  - Parameters: `boss_type`, `modifier_type`, `username`, `new_tier`
+- **`clan-house-purchased`** - Triggered when a clan house is purchased
+  - Parameters: None
+- **`upgrade-purchased`** - Triggered when a clan upgrade is purchased
+  - Parameters: `upgrade_type`
+
+#### Example Clan Action Request
+
+```
+POST /clan
+Headers:
+  Authorization: your-configured-token
+  Content-Type: application/json; charset=utf-8
+
+Body:
+{
+  "metadata": {
+    "playerName": "PlayerName",
+    "gameMode": "Default",
+    "clanName": "ClanName",
+    "timestamp": "1743177263",
+    "clientVersion": "1.5.1"
+  },
+  "params": {
+    "action": "skilling-ticket-received",
+    "skill": "Fishing",
+    "amount": "1",
+    "username": "PlayerName"
+  }
+}
+```
+
 ## Adding Custom Webhook Types
 
 Developers can contribute additional webhook types by:


### PR DESCRIPTION
## What
Adds webhooks for a subset of clan notifications. I added the actions that made most sense to me:
- Application Received
- Clan Boss Modifier Purchased
- Daily Combat Quest Progressed
- Daily Quests Updated
- Daily Skilling Quest Progressed
- Guild House Purchased
- Guild Member Demoted
- Guild Member Kicked
- Guild Member Logged In
- Guild Member Logged Out
- Guild Member Promoted
- Item Sent To Vault
- Items Sent To Vault
- Item Withdrawn From Vault
- Joined Guild
- Player Left Guild
- Skilling Ticket Received
- Upgrade Purchased

## How
This adds post fix patches for the handlers for the various guild network messages.

## Example
![image](https://github.com/user-attachments/assets/fa37c323-1dc5-4e9b-9999-08bcaf679f93)